### PR TITLE
[FEATURE] Add ``episode_return`` to ``VectorizedEnvMixin``

### DIFF
--- a/src/rejax/algos/dqn.py
+++ b/src/rejax/algos/dqn.py
@@ -170,6 +170,7 @@ class DQN(
             last_obs=next_obs,
             env_state=env_state,
             global_step=ts.global_step + self.num_envs,
+            episode_return=(ts.episode_return + rewards) * (1 - dones),
         )
         return ts, minibatch
 

--- a/src/rejax/algos/iqn.py
+++ b/src/rejax/algos/iqn.py
@@ -184,6 +184,7 @@ class IQN(
             last_obs=next_obs,
             env_state=env_state,
             global_step=ts.global_step + self.num_envs,
+            episode_return=(ts.episode_return + rewards) * (1 - dones),
         )
         return ts, minibatch
 

--- a/src/rejax/algos/mixins.py
+++ b/src/rejax/algos/mixins.py
@@ -47,6 +47,7 @@ class VectorizedEnvMixin(struct.PyTreeNode):
             "last_obs": obs,
             "global_step": 0,
             "last_done": jnp.zeros(self.num_envs, dtype=bool),
+            "episode_return": jnp.zeros(self.num_envs, dtype=jnp.float32),
         }
 
 

--- a/src/rejax/algos/ppo.py
+++ b/src/rejax/algos/ppo.py
@@ -160,6 +160,7 @@ class PPO(OnPolicyMixin, NormalizeObservationsMixin, NormalizeRewardsMixin, Algo
                 last_obs=next_obs,
                 last_done=done,
                 global_step=ts.global_step + self.num_envs,
+                episode_return=(ts.episode_return + reward) * (1 - done),
             )
             return ts, transition
 

--- a/src/rejax/algos/pqn.py
+++ b/src/rejax/algos/pqn.py
@@ -137,6 +137,7 @@ class PQN(
                 last_obs=next_obs,
                 last_done=done,
                 global_step=ts.global_step + self.num_envs,
+                episode_return=(ts.episode_return + reward) * (1 - done),
             )
             return ts, transition
 

--- a/src/rejax/algos/sac.py
+++ b/src/rejax/algos/sac.py
@@ -221,6 +221,7 @@ class SAC(
             last_obs=next_obs,
             env_state=env_state,
             global_step=ts.global_step + self.num_envs,
+            episode_return=(ts.episode_return + rewards) * (1 - dones),
         )
         return ts, minibatch
 

--- a/src/rejax/algos/td3.py
+++ b/src/rejax/algos/td3.py
@@ -289,6 +289,7 @@ class TD3(
             last_obs=next_obs,
             env_state=env_state,
             global_step=ts.global_step + self.num_envs,
+            episode_return=(ts.episode_return + rewards) * (1 - dones),
         )
         return ts, minibatch
 


### PR DESCRIPTION
## Summary
This PR introduces an ``episode_return`` field to the ``VectorizedEnvMixin`` class to track non-discounted cumulative returns.

## Why is this useful?
This feature improves debugging by providing a metric for algorithmic performance and allows developers to implement advanced stopping criteria, such as [CVaR Rejection Sampling](https://arxiv.org/pdf/2309.14597), based on episode returns.