### PR TITLE
Add new maybe_update_target_params method to TargetNetworkMixin

### DIFF
--- a/src/rejax/algos/dqn.py
+++ b/src/rejax/algos/dqn.py
@@ -106,20 +106,11 @@ class DQN(
 
         ts = jax.lax.cond(start_training, lambda: do_updates(ts), lambda: ts)
 
-        # Update target network
-        if self.target_update_freq == 1:
-            target_params = self.polyak_update(ts.q_ts.params, ts.q_target_params)
-        else:
-            update_target_params = (
-                ts.global_step % self.target_update_freq
-                <= old_global_step % self.target_update_freq
+        ts = ts.replace(
+            q_target_params=self.update_target_params(
+                ts.q_ts.params, ts.q_target_params, ts.global_step, old_global_step
             )
-            target_params = jax.tree.map(
-                lambda q, qt: jax.lax.select(update_target_params, q, qt),
-                self.polyak_update(ts.q_ts.params, ts.q_target_params),
-                ts.q_target_params,
-            )
-        ts = ts.replace(q_target_params=target_params)
+        )
 
         return ts
 

--- a/src/rejax/algos/dqn.py
+++ b/src/rejax/algos/dqn.py
@@ -107,7 +107,7 @@ class DQN(
         ts = jax.lax.cond(start_training, lambda: do_updates(ts), lambda: ts)
 
         ts = ts.replace(
-            q_target_params=self.update_target_params(
+            q_target_params=self.maybe_update_target_params(
                 ts.q_ts.params, ts.q_target_params, ts.global_step, old_global_step
             )
         )

--- a/src/rejax/algos/iqn.py
+++ b/src/rejax/algos/iqn.py
@@ -121,20 +121,11 @@ class IQN(
 
         ts = jax.lax.cond(start_training, lambda: do_updates(ts), lambda: ts)
 
-        # Update target network
-        if self.target_update_freq == 1:
-            target_params = self.polyak_update(ts.q_ts.params, ts.q_target_params)
-        else:
-            update_target_params = (
-                ts.global_step % self.target_update_freq
-                <= old_global_step % self.target_update_freq
+        ts = ts.replace(
+            q_target_params=self.update_target_params(
+                ts.q_ts.params, ts.q_target_params, ts.global_step, old_global_step
             )
-            target_params = jax.tree.map(
-                lambda q, qt: jax.lax.select(update_target_params, q, qt),
-                self.polyak_update(ts.q_ts.params, ts.q_target_params),
-                ts.q_target_params,
-            )
-        ts = ts.replace(q_target_params=target_params)
+        )
         return ts
 
     def collect_transitions(self, ts, epsilon, uniform=False):

--- a/src/rejax/algos/iqn.py
+++ b/src/rejax/algos/iqn.py
@@ -122,7 +122,7 @@ class IQN(
         ts = jax.lax.cond(start_training, lambda: do_updates(ts), lambda: ts)
 
         ts = ts.replace(
-            q_target_params=self.update_target_params(
+            q_target_params=self.maybe_update_target_params(
                 ts.q_ts.params, ts.q_target_params, ts.global_step, old_global_step
             )
         )

--- a/src/rejax/algos/mixins.py
+++ b/src/rejax/algos/mixins.py
@@ -163,7 +163,7 @@ class TargetNetworkMixin(struct.PyTreeNode):
     polyak: chex.Scalar = struct.field(pytree_node=True, default=0.99)
 
     def maybe_update_target_params(self, params, target_params, step, previous_step):
-        # Returns target_params if polyak=0
+        # Returns params if polyak=0
         new_target_params = jax.tree.map(
             lambda p, tp: tp * self.polyak + p * (1 - self.polyak),
             params,

--- a/src/rejax/algos/mixins.py
+++ b/src/rejax/algos/mixins.py
@@ -162,30 +162,19 @@ class TargetNetworkMixin(struct.PyTreeNode):
     target_update_freq: int = struct.field(pytree_node=False, default=1)
     polyak: chex.Scalar = struct.field(pytree_node=True, default=0.99)
 
-    def polyak_update(self, params, target_params):
-        return jax.tree.map(
+    def maybe_update_target_params(self, params, target_params, step, previous_step):
+        # Returns target_params if polyak=0
+        new_target_params = jax.tree.map(
             lambda p, tp: tp * self.polyak + p * (1 - self.polyak),
             params,
             target_params,
         )
 
-    def update_target_params(self, params, target_params, step, previous_step=None):
-        new_target_params = self.polyak_update(params, target_params)
-        if self.target_update_freq == 1:
-            return new_target_params
-
-        if previous_step is None:
-            do_update = step % self.target_update_freq == 0
-        else:
-            do_update = (
-                step % self.target_update_freq
-                <= previous_step % self.target_update_freq
-            )
-        return jax.tree.map(
-            lambda new, old: jax.lax.select(do_update, new, old),
-            new_target_params,
-            target_params,
+        do_update = (step // self.target_update_freq) > (
+            previous_step // self.target_update_freq
         )
+
+        return jax.lax.cond(do_update, lambda: new_target_params, lambda: target_params)
 
 
 class RMSState(struct.PyTreeNode):

--- a/src/rejax/algos/mixins.py
+++ b/src/rejax/algos/mixins.py
@@ -169,6 +169,24 @@ class TargetNetworkMixin(struct.PyTreeNode):
             target_params,
         )
 
+    def update_target_params(self, params, target_params, step, previous_step=None):
+        new_target_params = self.polyak_update(params, target_params)
+        if self.target_update_freq == 1:
+            return new_target_params
+
+        if previous_step is None:
+            do_update = step % self.target_update_freq == 0
+        else:
+            do_update = (
+                step % self.target_update_freq
+                <= previous_step % self.target_update_freq
+            )
+        return jax.tree.map(
+            lambda new, old: jax.lax.select(do_update, new, old),
+            new_target_params,
+            target_params,
+        )
+
 
 class RMSState(struct.PyTreeNode):
     mean: chex.Array

--- a/src/rejax/algos/sac.py
+++ b/src/rejax/algos/sac.py
@@ -160,7 +160,7 @@ class SAC(
         ts = jax.lax.cond(start_training, lambda: do_updates(ts), lambda: ts)
 
         ts = ts.replace(
-            critic_target_params=self.update_target_params(
+            critic_target_params=self.maybe_update_target_params(
                 ts.critic_ts.params,
                 ts.critic_target_params,
                 ts.global_step,

--- a/src/rejax/algos/sac.py
+++ b/src/rejax/algos/sac.py
@@ -159,22 +159,14 @@ class SAC(
         start_training = ts.global_step > self.fill_buffer
         ts = jax.lax.cond(start_training, lambda: do_updates(ts), lambda: ts)
 
-        # Update target network
-        if self.target_update_freq == 1:
-            target_params = self.polyak_update(
-                ts.critic_ts.params, ts.critic_target_params
-            )
-        else:
-            update_target_params = (
-                ts.global_step % self.target_update_freq
-                <= old_global_step % self.target_update_freq
-            )
-            target_params = jax.tree.map(
-                lambda q, qt: jax.lax.select(update_target_params, q, qt),
-                self.polyak_update(ts.critic_ts.params, ts.critic_target_params),
+        ts = ts.replace(
+            critic_target_params=self.update_target_params(
+                ts.critic_ts.params,
                 ts.critic_target_params,
+                ts.global_step,
+                old_global_step,
             )
-        ts = ts.replace(critic_target_params=target_params)
+        )
 
         return ts
 
@@ -182,18 +174,14 @@ class SAC(
         rng, rng_action = jax.random.split(ts.rng)
         ts = ts.replace(rng=rng)
 
-        def sample_policy(rng):
-            if self.normalize_observations:
-                last_obs = self.normalize_obs(ts.obs_rms_state, ts.last_obs)
-            else:
-                last_obs = ts.last_obs
+        if self.normalize_observations:
+            last_obs = self.normalize_obs(ts.obs_rms_state, ts.last_obs)
+        else:
+            last_obs = ts.last_obs
 
-            actions = self.actor.apply(
-                ts.actor_ts.params, last_obs, rng_action, method="act"
-            )
-            return actions
-
-        actions = sample_policy(rng_action)
+        actions = self.actor.apply(
+            ts.actor_ts.params, last_obs, rng_action, method="act"
+        )
 
         rng, rng_steps = jax.random.split(ts.rng)
         ts = ts.replace(rng=rng)

--- a/src/rejax/algos/td3.py
+++ b/src/rejax/algos/td3.py
@@ -216,13 +216,13 @@ class TD3(
         ts = jax.lax.cond(start_training, do_updates, lambda ts: ts, ts)
 
         ts = ts.replace(
-            critic_target_params=self.update_target_params(
+            critic_target_params=self.maybe_update_target_params(
                 ts.critic_ts.params,
                 ts.critic_target_params,
                 ts.global_step,
                 old_global_step,
             ),
-            actor_target_params=self.update_target_params(
+            actor_target_params=self.maybe_update_target_params(
                 ts.actor_ts.params,
                 ts.actor_target_params,
                 ts.global_step,

--- a/src/rejax/algos/td3.py
+++ b/src/rejax/algos/td3.py
@@ -215,27 +215,20 @@ class TD3(
         start_training = ts.global_step > self.fill_buffer
         ts = jax.lax.cond(start_training, do_updates, lambda ts: ts, ts)
 
-        # Update target networks
-        if self.target_update_freq == 1:
-            critic_tp = self.polyak_update(ts.critic_ts.params, ts.critic_target_params)
-            actor_tp = self.polyak_update(ts.actor_ts.params, ts.actor_target_params)
-        else:
-            update_target_params = (
-                ts.global_step % self.target_update_freq
-                <= old_global_step % self.target_update_freq
-            )
-            critic_tp = jax.tree.map(
-                lambda q, qt: jax.lax.select(update_target_params, q, qt),
-                self.polyak_update(ts.critic_ts.params, ts.critic_target_params),
+        ts = ts.replace(
+            critic_target_params=self.update_target_params(
+                ts.critic_ts.params,
                 ts.critic_target_params,
-            )
-            actor_tp = jax.tree.map(
-                lambda pi, pit: jax.lax.select(update_target_params, pi, pit),
-                self.polyak_update(ts.actor_ts.params, ts.actor_target_params),
+                ts.global_step,
+                old_global_step,
+            ),
+            actor_target_params=self.update_target_params(
+                ts.actor_ts.params,
                 ts.actor_target_params,
-            )
-
-        ts = ts.replace(critic_target_params=critic_tp, actor_target_params=actor_tp)
+                ts.global_step,
+                old_global_step,
+            ),
+        )
         return ts
 
     def collect_transitions(self, ts, uniform=False):


### PR DESCRIPTION
The logic for train_iteration=x (directly updating the target network every x iterations) and train_iteration=1 (polyak updates) was separated and duplicated for many `TargetNetwork` algorithms. 
I've consolidated this into a single method that is in the `TargetNetworkMixin` class. Granted that this "new" API can be confusing, as it's not common to do polyak every x steps. 
I've updated all the TargetNetwork algorithms: `SAC`, `TD3`, `DQN`, `IQN`. 

All tests pass.

