### PR TITLE
Fix: issue with not setting buffer as full

### DIFF
--- a/src/rejax/buffers.py
+++ b/src/rejax/buffers.py
@@ -33,13 +33,21 @@ class CircularBuffer(struct.PyTreeNode):
     def extend(self, batch: chex.ArrayTree) -> "CircularBuffer":
         batch_flat, _ = jax.tree.flatten(batch)
         batch_size = batch_flat[0].shape[0]
+        write_index = self.index
+        write_size = batch_size
 
-        idx = self.index + jnp.arange(batch_size)
-        idx = idx % self.size
+        if batch_size > self.size:
+            batch = jax.tree.map(lambda b: b[-self.size :], batch)
+            write_index = (
+                self.index + batch_size - self.size
+            ) % self.size  # To preserve order in buffer.
+            write_size = self.size
+
+        idx = (write_index + jnp.arange(write_size)) % self.size
         data = jax.tree.map(lambda arr, b: arr.at[idx].set(b), self.data, batch)
 
         next_index = (self.index + batch_size) % self.size
-        full = jnp.logical_or(self.full, next_index < self.index)
+        full = jnp.logical_or(self.full, self.index + batch_size >= self.size)
         return self.replace(data=data, index=next_index, full=full)
 
 

--- a/src/rejax/buffers.py
+++ b/src/rejax/buffers.py
@@ -39,7 +39,7 @@ class CircularBuffer(struct.PyTreeNode):
         data = jax.tree.map(lambda arr, b: arr.at[idx].set(b), self.data, batch)
 
         next_index = (self.index + batch_size) % self.size
-        full = jnp.logical_or(self.full, next_index == 0)
+        full = jnp.logical_or(self.full, next_index < self.index)
         return self.replace(data=data, index=next_index, full=full)
 
 

--- a/src/rejax/buffers.py
+++ b/src/rejax/buffers.py
@@ -31,6 +31,15 @@ class CircularBuffer(struct.PyTreeNode):
 
     @jax.jit
     def extend(self, batch: chex.ArrayTree) -> "CircularBuffer":
+        """Add received batch to the buffer. When batch size is larger than the buffer,
+        only the last self.size entries from the batch are added.
+
+        Args:
+            batch (chex.ArrayTree): Batch of new data.
+
+        Returns:
+            CircularBuffer: The updated circular buffer.
+        """
         batch_flat, _ = jax.tree.flatten(batch)
         batch_size = batch_flat[0].shape[0]
         write_index = self.index
@@ -100,7 +109,7 @@ class ReplayBuffer(CircularBuffer):
 
     @partial(jax.jit, static_argnames=("num"))
     def sample(self, num: int, rng: chex.PRNGKey) -> Minibatch:
-        """Samples a minibatch of transitions from the buffer, without replacement.
+        """Samples a minibatch of transitions from the buffer, with replacement.
         Note that this function does not check if enough transitions are stored, and
         might return the same transition multiple times.
 

--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -1,0 +1,33 @@
+import unittest
+
+import jax.numpy as jnp
+
+from rejax.buffers import CircularBuffer
+
+
+class TestCircularBuffer(unittest.TestCase):
+    def test_extend_marks_full_when_batch_wraps_without_landing_on_zero(self):
+        buffer = CircularBuffer.empty(10, jnp.zeros(10, dtype=jnp.int32))
+
+        buffer = buffer.extend(jnp.arange(8, dtype=jnp.int32))
+
+        self.assertFalse(bool(buffer.full))
+
+        buffer = buffer.extend(jnp.arange(8, 11, dtype=jnp.int32))
+
+        self.assertTrue(bool(buffer.full))
+        self.assertEqual(int(buffer.index), 1)
+        self.assertEqual(int(buffer.num_entries), 10)
+
+    def test_extend_with_batch_larger_than_buffer_keeps_latest_entries(self):
+        buffer = CircularBuffer.empty(5, jnp.zeros(5, dtype=jnp.int32))
+
+        buffer = buffer.extend(jnp.arange(-2, 0, dtype=jnp.int32))
+
+        self.assertFalse(bool(buffer.full))
+
+        buffer = buffer.extend(jnp.arange(7, dtype=jnp.int32))
+
+        self.assertTrue(bool(buffer.full))
+        self.assertEqual(int(buffer.index), 4)
+        self.assertEqual(buffer.data.tolist(), [3, 4, 5, 6, 2])


### PR DESCRIPTION
This happens when batch size doesn't divide buffer size.
With new change, this issue would only happen in case batch size is greater than the buffer size(which shouldn't happen).