### PR TITLE
Add: mujoco_playground wrapper

### DIFF
--- a/configs/mujoco_playground/halfcheetah.yaml
+++ b/configs/mujoco_playground/halfcheetah.yaml
@@ -1,0 +1,63 @@
+# tuned
+sac:
+  env: mujoco_playground/halfcheetah
+  agent_kwargs:
+    activation: tanh
+  num_envs: 128
+  buffer_size: 1_000_000
+  fill_buffer: 10_000
+  batch_size: 512
+  learning_rate: 0.00020495107742294415
+  num_epochs: 128
+  total_timesteps: 5242880
+  eval_freq: 32768
+  gamma: 0.98
+  polyak: 0.995
+  target_entropy_ratio: 0
+  normalize_observations: true
+
+
+# tuned
+ppo:
+  env: mujoco_playground/halfcheetah
+  agent_kwargs:
+    activation: tanh
+  num_envs: 32
+  num_steps: 32
+  num_epochs: 2
+  num_minibatches: 2
+  learning_rate: 0.0017203361125365498
+  max_grad_norm: 5
+  total_timesteps: 5242880
+  eval_freq: 32768
+  gamma: 0.99
+  gae_lambda: 0.8
+  clip_eps: 0.2
+  ent_coef: 0.01
+  vf_coef: 0.5
+  normalize_observations: true
+
+
+# tuned
+td3:
+  env: mujoco_playground/halfcheetah
+  actor_kwargs:
+    activation: tanh
+  critic_kwargs:
+    activation: tanh
+  num_envs: 128
+  buffer_size: 1048576
+  fill_buffer: 8192
+  batch_size: 512
+  learning_rate: 0.0001199272452295516
+  num_epochs: 128
+  total_timesteps: 5242880
+  eval_freq: 262144
+  gamma: 0.99
+  polyak: 0.99
+  max_grad_norm: 5
+  exploration_noise: 0.3
+  target_noise: 0.8
+  target_noise_clip: 0.6
+  policy_delay: 1
+  normalize_observations: true

--- a/src/rejax/compat/__init__.py
+++ b/src/rejax/compat/__init__.py
@@ -10,6 +10,10 @@ _create_fns = {
     "gymnasium": ("rejax.compat.gymnasium2gymnax", "create_gymnasium"),
     "kinetix": ("rejax.compat.kinetix2gymnax", "create_kinetix"),
     "craftax": ("rejax.compat.craftax2gymnax", "create_craftax"),
+    "mujoco_playground": (
+        "rejax.compat.mujoco_playground2gymnax",
+        "create_mujoco_playground",
+    ),
 }
 
 

--- a/src/rejax/compat/mujoco_playground2gymnax.py
+++ b/src/rejax/compat/mujoco_playground2gymnax.py
@@ -1,0 +1,72 @@
+import warnings
+from copy import copy
+
+from flax import struct
+from gymnax.environments import spaces
+from gymnax.environments.environment import Environment as GymnaxEnv
+from jax import numpy as jnp
+import mujoco_playground
+
+
+def create_mujoco_playground(env_name, **kwargs):
+    env = mujoco_playground.registry.load(env_name)
+    cfg = mujoco_playground.registry.get_default_config(env_name)
+    env = MujocoPlayground2GymnaxEnv(env, cfg)
+    return env, env.default_params
+
+
+@struct.dataclass
+class EnvParams:
+    # CAUTION: Passing params with a different value than on init has no effect
+    max_steps_in_episode: int = 1000
+
+
+class MujocoPlayground2GymnaxEnv(GymnaxEnv):
+    def __init__(self, env, cfg):
+        self.env = env
+        self.max_steps_in_episode = cfg.episode_length
+
+    @property
+    def default_params(self):
+        return EnvParams(max_steps_in_episode=self.max_steps_in_episode)
+
+    def step_env(self, key, state, action, params):
+        state = self.env.step(state, action)
+        return state.obs, state, state.reward, state.done.astype(bool), state.info
+
+    def reset_env(self, key, params):
+        state = self.env.reset(key)
+        return state.obs, state
+
+    def get_obs(self, state):
+        return state.obs
+
+    def is_terminal(self, state):
+        return state.done.astype(bool)
+
+    @property
+    def name(self):
+        return self.env.unwrapped.__class__.__name__
+
+    def action_space(self, params):
+        # All mjx evironments should have action limit of -1 to 1
+        return spaces.Box(low=-1, high=1, shape=(self.env.action_size,))
+
+    def observation_space(self, params):
+        # All mjx evironments should have observation limit of -inf to inf
+        return spaces.Box(
+            low=-jnp.inf, high=jnp.inf, shape=(self.env.observation_size,)
+        )
+
+    @property
+    def num_actions(self) -> int:
+        return self.env.action_size
+
+    def __deepcopy__(self, memo):
+        warnings.warn(
+            f"Trying to deepcopy {type(self).__name__}, which contains a mujoco_playground env,"
+            "so a shallow copy is returned.",
+            category=RuntimeWarning,
+            stacklevel=2,
+        )
+        return copy(self)

--- a/src/rejax/compat/mujoco_playground2gymnax.py
+++ b/src/rejax/compat/mujoco_playground2gymnax.py
@@ -1,11 +1,11 @@
 import warnings
 from copy import copy
 
+import mujoco_playground
 from flax import struct
 from gymnax.environments import spaces
 from gymnax.environments.environment import Environment as GymnaxEnv
 from jax import numpy as jnp
-import mujoco_playground
 
 
 def create_mujoco_playground(env_name, **kwargs):
@@ -64,8 +64,8 @@ class MujocoPlayground2GymnaxEnv(GymnaxEnv):
 
     def __deepcopy__(self, memo):
         warnings.warn(
-            f"Trying to deepcopy {type(self).__name__}, which contains a mujoco_playground env,"
-            "so a shallow copy is returned.",
+            f"Trying to deepcopy {type(self).__name__}, which contains a"
+            "mujoco_playground env, so a shallow copy is returned.",
             category=RuntimeWarning,
             stacklevel=2,
         )


### PR DESCRIPTION
I think it would be nice to have wrapper also for mujoco_playground.
However, I must admit that I don't have expertise in mujoco_playground and I'm not 100% sure if this is correctly written wrapper. I just looked at other implementations and checked in the debugger whether things from mujoco_playground env looks as if they can be passed as those required by the gymnax API.
In particular, i'm not 100% whether bounds for state/actions are correct or whether some additional wrappers should be applied.
And strangely i cannot find any repositories using mujoco_playground.